### PR TITLE
Bug in data length calculation to encode message when data is null

### DIFF
--- a/src/main/java/bftsmart/communication/client/netty/NettyTOMMessageEncoder.java
+++ b/src/main/java/bftsmart/communication/client/netty/NettyTOMMessageEncoder.java
@@ -59,7 +59,7 @@ public class NettyTOMMessageEncoder extends MessageToByteEncoder<TOMMessage> {
 
         //****** ROBIN BEGIN ******//
         byte[] privateData = sm.getPrivateContent();
-        dataLength += Integer.BYTES + (privateData == null ? -1 : privateData.length);
+        dataLength += Integer.BYTES + (privateData == null ? 0 : privateData.length);
         //****** ROBIN END ******//
         
         /* msg size */


### PR DESCRIPTION
When there is no privateData to encode, the dataLength is reduced by 1 instead of remaining the same, causing reads to exceed the buffer size.